### PR TITLE
fix: ipv4 getting rejected due to isIp package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ function ipv6Check (params) {
 }
 
 export default (ip) => {
-  if (isIp.v4(ip) || ip.startsWith('0')) {
+  if (isIp.v4(ip) || ip.startsWith('0') || ip.split('.').length === 4) {
     return ipv4Check(ip)
   }
   return ipv6Check(ip)


### PR DESCRIPTION
After doing my research, it appears that the IP `127.0.0.01` is getting rejected by isIp package

After the below change, `127.0.0.1` and `127.0.0.01` both returning `true` as private IPs