### PR TITLE
keep Netmask map results around, instead of re-computing each time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,10 +28,10 @@ const PRIVATE_IP_RANGES = [
   '255.255.255.255/32'
 ]
 
-function ipv4_check (ip_addr) {
-  const blocks = [...PRIVATE_IP_RANGES].map(ip_range => new Netmask(ip_range))
+const NETMASK_RANGES = PRIVATE_IP_RANGES.map(ip_range => new Netmask(ip_range))
 
-  for (let r of blocks) {
+function ipv4_check (ip_addr) {
+  for (let r of NETMASK_RANGES) {
     if (r.contains(ip_addr)) return true
   }
 


### PR DESCRIPTION
It seemed unnecessary / inefficient to build up the `blocks` array during each call to `ipv4_check`.

This change builds the `Netmask` array map, and keeps it around for re-use during each `ipv4_check` call.