### PR TITLE
Ship type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.1",
   "description": "Check if IP address is private.",
   "main": "index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/frenchbread/private-ip.git"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "commonjs",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
Now that private-ip is written in TypeScript, it can ship type definitions; this way, TypeScript projects which use private-ip will always have current definitions and will no longer need to install the `@types/private-ip` package.