### PR TITLE
chore: migrate to @chainsafe/is-ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or
 ### Usage
 
 ```js
-const is_ip_private = require('private-ip')
+import is_ip_private from 'private-ip'
 
 is_ip_private('10.0.0.0')
 // => true

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 'use strict'
 
-module.exports = require('./lib').default
+import is_ip_private from './lib/index.js'
+export default is_ip_private

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
         "ip-regex": "^4.3.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^4.0.0",
         "netmask": "^2.0.2"
       },
       "devDependencies": {
@@ -20,6 +20,11 @@
         "rimraf": "^3.0.2",
         "typescript": "^4.7.4"
       }
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1064,31 +1069,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-ip": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
-      "integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
-      "dependencies": {
-        "ip-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-ip/node_modules/ip-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2043,6 +2023,11 @@
     }
   },
   "dependencies": {
+    "@chainsafe/is-ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz",
+      "integrity": "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2796,21 +2781,6 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
-      }
-    },
-    "is-ip": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
-      "integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
-      "requires": {
-        "ip-regex": "^5.0.0"
-      },
-      "dependencies": {
-        "ip-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
-          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-        }
       }
     },
     "is-number": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ip-regex": "^4.3.0",
         "ipaddr.js": "^2.0.1",
-        "is-ip": "^3.1.0",
+        "is-ip": "^4.0.0",
         "netmask": "^2.0.2"
       },
       "devDependencies": {
@@ -1065,14 +1065,28 @@
       }
     },
     "node_modules/is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
+      "integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
       "dependencies": {
-        "ip-regex": "^4.0.0"
+        "ip-regex": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-ip/node_modules/ip-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -2785,11 +2799,18 @@
       }
     },
     "is-ip": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-      "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
+      "integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
       "requires": {
-        "ip-regex": "^4.0.0"
+        "ip-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "ip-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+          "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
+        }
       }
     },
     "is-number": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "ip-regex": "^4.3.0",
     "ipaddr.js": "^2.0.1",
-    "is-ip": "^3.1.0",
+    "is-ip": "^4.0.0",
     "netmask": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "ip-regex": "^4.3.0",
     "ipaddr.js": "^2.0.1",
-    "is-ip": "^4.0.0",
+    "@chainsafe/is-ip": "^2.0.1",
     "netmask": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "private-ip",
   "version": "2.3.4",
   "description": "Check if IP address is private.",
-  "main": "index.js",
+  "exports": "./index.js",
+  "type": "module",
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
@@ -54,5 +55,8 @@
     "ipaddr.js": "^2.0.1",
     "@chainsafe/is-ip": "^2.0.1",
     "netmask": "^2.0.2"
+  },
+  "engines": {
+    "node": ">=14.16"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Netmask } from 'netmask'
 import ip_regex from 'ip-regex'
-import { isIP } from 'is-ip'
+import { isIP } from '@chainsafe/is-ip'
 import { isValid as is_valid, parse, IPv4 } from 'ipaddr.js'
 
 const PRIVATE_IP_RANGES = [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Netmask } from 'netmask'
 import ip_regex from 'ip-regex'
-import is_ip from 'is-ip'
+import { isIP } from 'is-ip'
 import { isValid as is_valid, parse, IPv4 } from 'ipaddr.js'
 
 const PRIVATE_IP_RANGES = [
@@ -62,7 +62,7 @@ export default (ip: string) => {
 
     if (parsed.kind() === 'ipv4') return ipv4_check((parsed as IPv4).toNormalizedString())
     else if (parsed.kind() === 'ipv6') return ipv6_check(ip)
-  } else if (is_ip(ip) && ip_regex.v6().test(ip)) return ipv6_check(ip)
+  } else if (isIP(ip) && ip_regex.v6().test(ip)) return ipv6_check(ip)
 
   return undefined
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { Netmask } from 'netmask'
 import ip_regex from 'ip-regex'
 import { isIP } from '@chainsafe/is-ip'
-import { isValid as is_valid, parse, IPv4 } from 'ipaddr.js'
+import ipaddr, { IPv4 } from 'ipaddr.js'
+const { isValid: is_valid, parse } = ipaddr
 
 const PRIVATE_IP_RANGES = [
   '0.0.0.0/8',

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-const test = require('ava')
-const is_ip_private = require('./')
+import test from 'ava'
+import is_ip_private from './index.js'
 
 const pub_ips = [
   '44.37.112.180',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
     "esModuleInterop": true,
     "declaration": true
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,10 +554,15 @@
   "resolved" "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   "version" "2.0.4"
 
-"ip-regex@^4.0.0", "ip-regex@^4.3.0":
+"ip-regex@^4.3.0":
   "integrity" "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
   "resolved" "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz"
   "version" "4.3.0"
+
+"ip-regex@^5.0.0":
+  "integrity" "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
+  "resolved" "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz"
+  "version" "5.0.0"
 
 "ipaddr.js@^2.0.1":
   "integrity" "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
@@ -603,12 +608,12 @@
   dependencies:
     "is-extglob" "^2.1.1"
 
-"is-ip@^3.1.0":
-  "integrity" "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q=="
-  "resolved" "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz"
-  "version" "3.1.0"
+"is-ip@^4.0.0":
+  "integrity" "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw=="
+  "resolved" "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz"
+  "version" "4.0.0"
   dependencies:
-    "ip-regex" "^4.0.0"
+    "ip-regex" "^5.0.0"
 
 "is-number@^7.0.0":
   "integrity" "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@chainsafe/is-ip@^2.0.1":
+  "integrity" "sha512-nqSJ8u2a1Rv9FYbyI8qpDhTYujaKEyLknNrTejLYoSWmdeg+2WB7R6BZqPZYfrJzDxVi3rl6ZQuoaEvpKRZWgQ=="
+  "resolved" "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.1.tgz"
+  "version" "2.0.1"
+
 "@nodelib/fs.scandir@2.1.5":
   "integrity" "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="
   "resolved" "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
@@ -559,11 +564,6 @@
   "resolved" "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz"
   "version" "4.3.0"
 
-"ip-regex@^5.0.0":
-  "integrity" "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw=="
-  "resolved" "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz"
-  "version" "5.0.0"
-
 "ipaddr.js@^2.0.1":
   "integrity" "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
   "resolved" "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz"
@@ -607,13 +607,6 @@
   "version" "4.0.3"
   dependencies:
     "is-extglob" "^2.1.1"
-
-"is-ip@^4.0.0":
-  "integrity" "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw=="
-  "resolved" "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz"
-  "version" "4.0.0"
-  dependencies:
-    "ip-regex" "^5.0.0"
 
 "is-number@^7.0.0":
   "integrity" "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="


### PR DESCRIPTION
**Motivation**
- ~is-ip 4.0.0 is the last performant version of is-ip (version 5.0.0 has a performance issue)~
- use @chainsafe/is-ip which is significantly faster

**Description**
~Migrate to is-ip 4.0.0~
Migrate to `@chainsafe/is-ip`