### PR TITLE
fix: add types to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "private-ip",
   "version": "3.0.1",
   "description": "Check if IP address is private.",
-  "exports": "./index.js",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "import": "./index.js"
+    }
+  },
   "type": "module",
   "types": "lib/index.d.ts",
   "repository": {


### PR DESCRIPTION
When TypeScript uses a `moduleResolution` of `Node16` or `NodeNext` and an `exports` map is encountered, `main`, `types` and `typings` entries declared on the `package.json` root are ignored so `types` needs to be present in the exports map.

Fixes this sort of error:

```
src/index.ts:19:23 - error TS7016: Could not find a declaration file for module 'private-ip'. '/path/to/node_modules/private-ip/index.js' implicitly has an 'any' type.
  There are types at '/path/to/node_modules/private-ip/lib/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'private-ip' library may need to update its package.json or typings.

19 import isPrivate from 'private-ip'
```